### PR TITLE
Add language selector

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -46,3 +46,9 @@ release_date:        August 12
 version_slurp:       Support for multiple syntax blocks
 size_min:            12.5
 repo:                https://github.com/riot/riot
+
+# Languages
+translations:
+  fr: v2.2.4
+  ja: v2.2.3
+  zh: v2.2.4

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -36,6 +36,7 @@
   -->
 
   <!-- style -->
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
   <link rel="stylesheet" href="/style.css">
 
 </head>
@@ -53,7 +54,17 @@
         <a href="https://muut.com/"><img id="muut-logo" src="/img/logo/muut.png"></a>
       </span>
 
-      <nav id="nav">{{ nav }}</nav>
+      <nav id="nav">
+        {{ nav }}
+        <a id="current-lang" href="#"><i class="fa fa-globe"></i> en</a>
+      </nav>
+
+      <nav id="langs">
+        <a href="/"><span>en</span> latest</a>
+        {% for lang in site.translations %}
+          <a href="/{{ lang[0] }}/"><span>{{ lang[0] }}</span> {{ lang[1] }}</a>
+        {% endfor %}
+      </nav>
 
     </header>
 
@@ -66,6 +77,12 @@
   <footer id="footer">
     <div class="wrap">
       <a href="/"><img src="/img/logo/riot120x.png"></a>
+      <nav>
+        <a href="/"><span>en</span> latest</a>
+        {% for lang in site.translations %}
+          <a href="/{{ lang[0] }}/"><span>{{ lang[0] }}</span> {{ lang[1] }}</a>
+        {% endfor %}
+      </nav>
       <nav>{{ nav }}</nav>
     </div>
   </footer>

--- a/_layouts/fr.html
+++ b/_layouts/fr.html
@@ -36,7 +36,8 @@
 	  -->
 
 	<!-- style -->
-	<link rel="stylesheet" href="/style.css">
+	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
+  <link rel="stylesheet" href="/style.css">
 
 </head>
 
@@ -47,13 +48,23 @@
 	<a id="fork" href="{{ site.repo }}">Fork me on GitHub</a>
 
 	<header id="header">
-      <span id="logo">
-        <a href="/fr/"><img id="riot-logo" src="/img/logo/riot120x.png"></a>
-        <strong>by</strong>
-        <a href="https://muut.com/"><img id="muut-logo" src="/img/logo/muut.png"></a>
-      </span>
+    <span id="logo">
+      <a href="/fr/"><img id="riot-logo" src="/img/logo/riot120x.png"></a>
+      <strong>by</strong>
+      <a href="https://muut.com/"><img id="muut-logo" src="/img/logo/muut.png"></a>
+    </span>
 
-		<nav id="nav">{{ nav }}</nav>
+		<nav id="nav">
+			{{ nav }}
+			<a id="current-lang" href="#"><i class="fa fa-globe"></i> fr</a>
+		</nav>
+
+		<nav id="langs">
+			<a href="/"><span>en</span> latest</a>
+			{% for lang in site.translations %}
+				<a href="/{{ lang[0] }}/"><span>{{ lang[0] }}</span> {{ lang[1] }}</a>
+			{% endfor %}
+		</nav>
 
 	</header>
 
@@ -66,6 +77,12 @@
 <footer id="footer">
 	<div class="wrap">
 		<a href="/fr/"><img src="/img/logo/riot120x.png"></a>
+		<nav>
+			<a href="/"><span>en</span> latest</a>
+			{% for lang in site.translations %}
+				<a href="/{{ lang[0] }}/"><span>{{ lang[0] }}</span> {{ lang[1] }}</a>
+			{% endfor %}
+		</nav>
 		<nav>{{ nav }}</nav>
 	</div>
 </footer>

--- a/_layouts/ja.html
+++ b/_layouts/ja.html
@@ -36,6 +36,7 @@
   -->
 
   <!-- style -->
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
   <link rel="stylesheet" href="/style.css">
 
 </head>
@@ -53,7 +54,17 @@
         <a href="https://muut.com/"><img id="muut-logo" src="/img/logo/muut.png"></a>
       </span>
 
-      <nav id="nav">{{ nav }}</nav>
+      <nav id="nav">
+        {{ nav }}
+        <a id="current-lang" href="#"><i class="fa fa-globe"></i> ja</a>
+      </nav>
+
+      <nav id="langs">
+        <a href="/"><span>en</span> latest</a>
+        {% for lang in site.translations %}
+          <a href="/{{ lang[0] }}/"><span>{{ lang[0] }}</span> {{ lang[1] }}</a>
+        {% endfor %}
+      </nav>
 
     </header>
 
@@ -66,6 +77,12 @@
   <footer id="footer">
     <div class="wrap">
       <a href="/ja/"><img src="/img/logo/riot120x.png"></a>
+      <nav>
+        <a href="/"><span>en</span> latest</a>
+        {% for lang in site.translations %}
+          <a href="/{{ lang[0] }}/"><span>{{ lang[0] }}</span> {{ lang[1] }}</a>
+        {% endfor %}
+      </nav>
       <nav>{{ nav }}</nav>
     </div>
   </footer>

--- a/_layouts/zh.html
+++ b/_layouts/zh.html
@@ -36,6 +36,7 @@
   -->
 
   <!-- style -->
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
   <link rel="stylesheet" href="/style.css">
 
 </head>
@@ -53,7 +54,17 @@
         <a href="https://muut.com/"><img id="muut-logo" src="/img/logo/muut.png"></a>
       </span>
 
-      <nav id="nav">{{ nav }}</nav>
+      <nav id="nav">
+        {{ nav }}
+        <a id="current-lang" href="#"><i class="fa fa-globe"></i> zh</a>
+      </nav>
+
+      <nav id="langs">
+        <a href="/"><span>en</span> latest</a>
+        {% for lang in site.translations %}
+          <a href="/{{ lang[0] }}/"><span>{{ lang[0] }}</span> {{ lang[1] }}</a>
+        {% endfor %}
+      </nav>
 
     </header>
 
@@ -66,6 +77,12 @@
   <footer id="footer">
     <div class="wrap">
       <a href="/zh/"><img src="/img/logo/riot120x.png"></a>
+      <nav>
+        <a href="/"><span>en</span> latest</a>
+        {% for lang in site.translations %}
+          <a href="/{{ lang[0] }}/"><span>{{ lang[0] }}</span> {{ lang[1] }}</a>
+        {% endfor %}
+      </nav>
       <nav>{{ nav }}</nav>
     </div>
   </footer>

--- a/script.js
+++ b/script.js
@@ -44,8 +44,23 @@
     }
   })
 
-  $('#current-lang')[0].addEventListener('click', function() {
-    $('#langs')[0].className = $('#langs')[0].className ? '' : 'open'
+  // language selector
+  var menu = $('#langs')[0]
+  function mClose(e) {
+    if (e && e.keyCode && e.keyCode != 27) return
+    doc.removeEventListener('keyup', mClose)
+    doc.removeEventListener('click', mClose)
+    menu.className = ''
+  }
+  function mOpen() {
+    doc.addEventListener('keyup', mClose)
+    doc.addEventListener('click', mClose)
+    menu.className = 'open'
+  }
+  $('#current-lang')[0].addEventListener('click', function(e) {
+    e.stopPropagation()
+    if (menu.className) mClose()
+      else mOpen()
   })
 
 })(document)

--- a/script.js
+++ b/script.js
@@ -44,4 +44,8 @@
     }
   })
 
+  $('#current-lang')[0].addEventListener('click', function() {
+    $('#langs')[0].className = $('#langs')[0].className ? '' : 'open'
+  })
+
 })(document)

--- a/style/_footer.scss
+++ b/style/_footer.scss
@@ -9,17 +9,29 @@
 
   img {
     width: 80px;
+    display: block;
   }
 
   nav {
-    margin: .6em 0 0 .3em;
-    max-width: 10em;
+    margin: .6em 1em 0 .3em;
+    width: 6em;
+    float: left;
 
     a {
       display: block;
       margin-bottom: .3em;
       font-size: 85%;
       color: #ccc;
+
+      span {
+        background-color: #ccc;
+        color: #454545;
+        border-radius: 2px;
+        display: inline-block;
+        width: 30px;
+        text-align: center;
+        margin-right: 3px;
+      }
     }
   }
 
@@ -27,6 +39,12 @@
     text-decoration: none;
     cursor: default;
     color: #777;
+  }
+
+  &:after {
+    content: "";
+    display: table;
+    clear: both;
   }
 }
 

--- a/style/_header.scss
+++ b/style/_header.scss
@@ -4,6 +4,7 @@
 
 #header {
   padding: .6rem 0 2em;
+  position: relative;
 }
 
 #riot-logo {
@@ -52,5 +53,67 @@
     a {
       margin: 0 .6em;
     }
+  }
+}
+
+#current-lang {
+  border-radius: 3px;
+  padding: 4px;
+
+  &::after {
+    margin-left: 2px;
+    content: "\25BE"
+  }
+
+  &:hover {
+    background-color: #eee;
+    text-decoration: none;
+  }
+}
+
+#langs {
+  display: none;
+
+  clear: both;
+  text-align: center;
+  background: #eee;
+  border-radius: 2px;
+
+  width: 170px;
+  font-size: 70%;
+  position: absolute;
+  right: 0;
+
+  a {
+    display: block;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    padding: 5px;
+    color: #999;
+
+    &:not(:first-child) {
+      border-top: 1px solid white;
+    }
+    &:hover {
+      text-decoration: none;
+      background-color: #e9e9e9;
+    }
+  }
+  a > span {
+    color: #aaa;
+    background: white;
+    padding: 0 7px;
+    border-radius: 3px;
+    margin-right: 2px;
+  }
+
+  @media (max-width: 600px) {
+    width: 100%;
+    font-size: 90%;
+    position: relative;
+  }
+
+  &.open {
+    display: block;
   }
 }

--- a/style/_header.scss
+++ b/style/_header.scss
@@ -75,11 +75,13 @@
   display: none;
 
   clear: both;
-  text-align: center;
-  background: #eee;
-  border-radius: 2px;
+  background: white;
+  border: 1px solid rgba(0,0,0,.2);
+  border-radius: 4px;
+  padding: 6px 0;
+  box-shadow: 0 2px 10px rgba(0,0,0,.3);
 
-  width: 170px;
+  width: auto;
   font-size: 70%;
   position: absolute;
   right: 0;
@@ -88,23 +90,21 @@
     display: block;
     text-transform: uppercase;
     letter-spacing: 1px;
-    padding: 5px;
+    padding: 5px 20px 5px 15px;
     color: #999;
-
-    &:not(:first-child) {
-      border-top: 1px solid white;
-    }
     &:hover {
       text-decoration: none;
       background-color: #e9e9e9;
     }
   }
   a > span {
-    color: #aaa;
-    background: white;
-    padding: 0 7px;
+    color: white;
+    background: #408bc2;
+    display: inline-block;
+    width: 2.5em;
+    text-align: center;
     border-radius: 3px;
-    margin-right: 2px;
+    margin-right: .5em;
   }
 
   @media (max-width: 600px) {


### PR DESCRIPTION
See #25.
This PR will add the section `translations` to `_config.yaml`:

```yaml
# Languages
translations:
  fr: v2.2.4
  ja: v2.2.3
  zh: v2.2.4
```

These languages and versions will appear in the language selector. If you click the `EN` link on header, the language menu will open:

Wider screen:
<img width="981" alt="riot js a react-like user interface micro-library" src="https://cloud.githubusercontent.com/assets/16032/10809709/9b03f81c-7e3c-11e5-989a-127366290b6c.png">

Narrow screen:
<img width="400" alt="riot js a react-like user interface micro-library" src="https://cloud.githubusercontent.com/assets/16032/10809711/a01e7e44-7e3c-11e5-9091-07d244b11725.png">

It also has a list on the footer.

<img width="723" alt="riot js a react-like user interface micro-library" src="https://cloud.githubusercontent.com/assets/16032/10809754/f712487a-7e3c-11e5-8941-6f225234d58f.png">
