### PR TITLE
ie9 and router

### DIFF
--- a/api/route.md
+++ b/api/route.md
@@ -11,7 +11,7 @@ The Riot Router is the minimal router implementation with such technologies:
 - pushState and history API
 - multiple routing groups
 - replacable parser
-- compatible with IE9 and higher
+- use polyfills for ie9 support and earlier.  Because ie.
 
 ## Setup routing
 


### PR DESCRIPTION
route logic uses history.pushState that is not supported on ie9.
specifically - calling riot.route('someurl') fails on ie9 with pushState error.  I don't see in the route logic how the code path would avoid the go function - and therefore the history.pushState call.