### PR TITLE
Fix typo in route.md.

### DIFF
--- a/api/route.md
+++ b/api/route.md
@@ -110,7 +110,7 @@ var subRoute = riot.route.create()
 subRoute('/fruit/apple', function() { /* */ })
 ```
 
-See also [Routing group](#routing-group) and [Routing priority](#routing-priority) section, for detail.
+See also [Routing group](#routing-groups) and [Routing priority](#routing-priority) section, for detail.
 
 ## Use router
 


### PR DESCRIPTION
It's really not much of a big deal, but the link was not working.