### PR TITLE
Update the link to the compiler from jsdelivr to rawgit

### DIFF
--- a/fr/guide/compiler.md
+++ b/fr/guide/compiler.md
@@ -26,7 +26,7 @@ Les tags personnalisés doivent être transformés en JavaScript avant que le na
 <script src="chemin/vers/javascript/avec-tags.js" type="riot/tag"></script>
 
 <!-- inclusion de riot.js et du compilateur -->
-<script src="//cdn.jsdelivr.net/g/riot@2.3(riot.min.js+compiler.min.js)"></script>
+<script src="//cdn.rawgit.com/riot/riot/master/riot+compiler.min.js"></script>
 
 
 <!-- montage normal -->

--- a/fr/guide/compiler.md
+++ b/fr/guide/compiler.md
@@ -26,7 +26,7 @@ Les tags personnalisés doivent être transformés en JavaScript avant que le na
 <script src="chemin/vers/javascript/avec-tags.js" type="riot/tag"></script>
 
 <!-- inclusion de riot.js et du compilateur -->
-<script src="//cdn.rawgit.com/riot/riot/master/riot+compiler.min.js"></script>
+<script src="https://cdn.jsdelivr.net/riot/2.3/riot+compiler.min.js"></script>
 
 
 <!-- montage normal -->

--- a/guide/compiler.md
+++ b/guide/compiler.md
@@ -26,7 +26,7 @@ Custom tags need to be transformed to JavaScript before the browser can execute 
 <script src="path/to/javascript/with-tags.js" type="riot/tag"></script>
 
 <!-- include riot.js and the compiler -->
-<script src="//cdn.rawgit.com/riot/riot/master/riot+compiler.min.js"></script>
+<script src="https://cdn.jsdelivr.net/riot/2.3/riot+compiler.min.js"></script>
 
 
 <!-- mount normally -->

--- a/guide/compiler.md
+++ b/guide/compiler.md
@@ -26,7 +26,7 @@ Custom tags need to be transformed to JavaScript before the browser can execute 
 <script src="path/to/javascript/with-tags.js" type="riot/tag"></script>
 
 <!-- include riot.js and the compiler -->
-<script src="//cdn.jsdelivr.net/g/riot@2.3(riot.min.js+compiler.min.js)"></script>
+<script src="//cdn.rawgit.com/riot/riot/master/riot+compiler.min.js"></script>
 
 
 <!-- mount normally -->

--- a/ja/guide/compiler.md
+++ b/ja/guide/compiler.md
@@ -26,7 +26,7 @@ title: コンパイラ
 <script src="path/to/javascript/with-tags.js" type="riot/tag"></script>
 
 <!-- riot.jsとコンパイラを読み込む -->
-<script src="//cdn.rawgit.com/riot/riot/master/riot+compiler.min.js"></script>
+<script src="https://cdn.jsdelivr.net/riot/2.3/riot+compiler.min.js"></script>
 
 
 <!-- 通常のマウント -->

--- a/ja/guide/compiler.md
+++ b/ja/guide/compiler.md
@@ -26,7 +26,7 @@ title: コンパイラ
 <script src="path/to/javascript/with-tags.js" type="riot/tag"></script>
 
 <!-- riot.jsとコンパイラを読み込む -->
-<script src="//cdn.jsdelivr.net/g/riot@2.3(riot.min.js+compiler.min.js)"></script>
+<script src="//cdn.rawgit.com/riot/riot/master/riot+compiler.min.js"></script>
 
 
 <!-- 通常のマウント -->

--- a/play/index.md
+++ b/play/index.md
@@ -25,7 +25,7 @@ You can mount this tag on HTML easily. Save the source above as `sample.tag`, an
     <!-- include the tag -->
     <script type="riot/tag" src="sample.tag"></script>
     <!-- include riot.js -->
-    <script src="https://cdn.rawgit.com/riot/riot/master/riot+compiler.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/riot/2.3/riot+compiler.min.js"></script>
     <!-- mount the tag -->
     <script>riot.mount('sample')</script>
   </body>

--- a/ru/guide/compiler.md
+++ b/ru/guide/compiler.md
@@ -25,7 +25,7 @@ title: Компилятор
 <script src="path/to/javascript/with-tags.js" type="riot/tag"></script>
 
 <!-- подключение riot.js с компилятором  -->
-<script src="//cdn.rawgit.com/riot/riot/master/riot+compiler.min.js"></script>
+<script src="https://cdn.jsdelivr.net/riot/2.3/riot+compiler.min.js"></script>
 
 
 <!-- монтирование -->

--- a/ru/guide/compiler.md
+++ b/ru/guide/compiler.md
@@ -25,7 +25,7 @@ title: Компилятор
 <script src="path/to/javascript/with-tags.js" type="riot/tag"></script>
 
 <!-- подключение riot.js с компилятором  -->
-<script src="//cdn.jsdelivr.net/g/riot@2.3(riot.min.js+compiler.min.js)"></script>
+<script src="//cdn.rawgit.com/riot/riot/master/riot+compiler.min.js"></script>
 
 
 <!-- монтирование -->

--- a/zh/guide/compiler.md
+++ b/zh/guide/compiler.md
@@ -25,7 +25,7 @@ title: 编译器
 <script src="path/to/javascript/with-tags.js" type="riot/tag"></script>
 
 <!-- 包含 riot.js 和编译器 -->
-<script src="//cdn.jsdelivr.net/g/riot@2.3(riot.min.js+compiler.min.js)"></script>
+<script src="//cdn.rawgit.com/riot/riot/master/riot+compiler.min.js"></script>
 
 <!-- 正常加载 -->
 <script>

--- a/zh/guide/compiler.md
+++ b/zh/guide/compiler.md
@@ -25,7 +25,7 @@ title: 编译器
 <script src="path/to/javascript/with-tags.js" type="riot/tag"></script>
 
 <!-- 包含 riot.js 和编译器 -->
-<script src="//cdn.rawgit.com/riot/riot/master/riot+compiler.min.js"></script>
+<script src="https://cdn.jsdelivr.net/riot/2.3/riot+compiler.min.js"></script>
 
 <!-- 正常加载 -->
 <script>

--- a/zh/play/index.md
+++ b/zh/play/index.md
@@ -25,7 +25,7 @@ description: 一系列用来展示采用 Riot 的好处的示例 Riot.
     <!-- 包含标签定义 -->
     <script type="riot/tag" src="sample.tag"></script>
     <!-- 包含 riot.js -->
-    <script src="https://cdn.rawgit.com/riot/riot/master/riot+compiler.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/riot/2.3/riot+compiler.min.js"></script>
     <!-- 加载标签实例 -->
     <script>riot.mount('sample')</script>
   </body>


### PR DESCRIPTION
The previous link was returning a 404. Furthermore it's consistent with the link provided on the playground page.