### PR TITLE
fix spelling errors in french translation

### DIFF
--- a/fr/api/compiler.md
+++ b/fr/api/compiler.md
@@ -8,7 +8,7 @@ class: apidoc
 
 ## Sur le navigateur
 
-Les méthodes suivantes s'appliquent uniquement aux navigateurs. Allez en [section serveur](#sur-le-serveur) si vous voulez compilez avec node ou io.js.
+Les méthodes suivantes s'appliquent uniquement aux navigateurs. Allez en [section serveur](#sur-le-serveur) si vous voulez compiler avec node ou io.js.
 
 ### <a name="compile"></a> riot.compile(callback)
 
@@ -20,7 +20,7 @@ riot.compile(function() {
 })
 ```
 
-Vous pouvez écartez l'appel à `riot.compile` et juste écrire:
+Vous pouvez écarter l'appel à `riot.compile` et juste écrire:
 
 ``` javascript
 var tags = riot.mount('*')
@@ -62,7 +62,7 @@ Une définition de tag est repérée si le premier caractère non vide est `<`, 
 
 ### <a name="compile-to-str"></a> riot.compile(tag, true)
 
-Compile le `tag` et le retourne sous forme de chaîne de caractères. Seule la transformation du tag en JavaScript est effectuée, le tag n'est pas exécuté sur le navigateur. Vous pouvez utiliser cette méthode pour par exemple mesurer la performance du compilateur.
+Compile le `tag` et le retourne sous forme de chaîne de caractères. Seule la transformation du tag en JavaScript est effectuée, le tag n'est pas exécuté sur le navigateur. Vous pouvez utiliser cette méthode pour mesurer la performance du compilateur par exemple.
 
 ``` js
 var js = riot.compile(my_tag.innerHTML, true)
@@ -165,5 +165,5 @@ Les parseurs prédéfinis sont:
 
 ## Changements dans la v2.3.0
 
-Dans les versions précédentes, les parenthèses échappées étaient conservées, en générant du code HTML et JavaScript parfois invalide. La version actuelle les supprime à une étape antérieure, après avoir passé le tag au parseur HTML et avant que le code JavaScript et les expressions soient envoyées au parseur JavaScript.
+Dans les versions précédentes, les parenthèses protégées étaient conservées, en générant du code HTML et JavaScript parfois invalide. La version actuelle les supprime à une étape antérieure, après avoir passé le tag au parseur HTML et avant que le code JavaScript et les expressions soient envoyées au parseur JavaScript.
 

--- a/fr/api/index.md
+++ b/fr/api/index.md
@@ -208,13 +208,13 @@ Vous pouvez également utiliser l'attribut `name` pour donner un autre nom au ta
 
   <child name="mon_tag_imbrique"></child>
 
-  // accèès au tag enfant
+  // accès au tag enfant
   var child = this.tags.mon_tag_imbrique
 
 </my-tag>
 ```
 
-Les tags enfant initialisés après que le tag parent afin que les méthodes et propriétés soient disponible lors de l'événement "mount".
+Les tags enfant sont initialisés après le tag parent afin que les méthodes et propriétés soient disponible lors de l'événement "mount".
 
 ``` html
 <my-tag>
@@ -243,7 +243,7 @@ Par exemple, en utilisant le tag suivant `my-post`
 </my-post>
 ```
 
-chaque fois que vous voulez inclure le tag `<my-post>` dand votre application
+chaque fois que vous voulez inclure le tag `<my-post>` dans votre application
 
 ``` html
 <my-post title="Quel superbe titre">
@@ -453,7 +453,7 @@ riot.tag('timer',
 Voir la [démo timer](http://jsfiddle.net/gnumanth/h9kuozp5/) et la doc API de [riot.tag](/api/#tag-instance) pour plus de détails sur les *limitations*.
 
 
-<span class="tag red">Attention</span> en utilisant `riot.tag` vous ne profiterez pas des avantages du compilateur et les fonctionnalités suivantes ne seront pas supportées:
+<span class="tag red">Attention</span> en utilisant `riot.tag` vous ne profiterez pas des avantages du compilateur et les fonctionnalités suivantes ne seront pas disponibles:
 
 1. Balises auto-fermantes
 2. Expressions sans guillemets. Ecrivez `value="{ val }"` au lieu de `value={ val }`

--- a/fr/api/observable.md
+++ b/fr/api/observable.md
@@ -59,7 +59,7 @@ el.on('all', function(event, param1, param2) {
 })
 ```
 
-En cas d'erreurs dans vos `callbacks`, l'instance observable émettra l'événement `error`:
+En cas d'erreur dans vos `callbacks`, l'instance observable émettra l'événement `error`:
 
 ``` js
 
@@ -136,7 +136,7 @@ el.trigger('start')
 
 ### <a name="trigger-args"></a> el.trigger(event, arg1 ... argN)
 
-Déclenche l'événement `event` sur l'élément `el` et appelle toutes les fonctions associées avec certains paramètres. N'importe quel nombre de paramètres supplémentaires peuvent être fournis aux fonctions de callback.
+Déclenche l'événement `event` sur l'élément `el` et appelle toutes les fonctions associées avec certains paramètres. N'importe quelle quantité de paramètres supplémentaires peut être fournie aux fonctions de callback.
 
 ``` js
 // écoute l'événement 'start' et attend des arguments supplémentaires

--- a/fr/api/route.md
+++ b/fr/api/route.md
@@ -110,7 +110,7 @@ var subRoute = riot.route.create()
 subRoute('/fruit/apple', function() { /* */ })
 ```
 
-Consulez les sections [Groupe de routage](#routing-group) et [Priorité de routage](#routing-priority) pour plus de détails.
+Consultez les sections [Groupe de routage](#routing-group) et [Priorité de routage](#routing-priority) pour plus de détails.
 
 ## Utilisation du routeur
 

--- a/fr/compare.md
+++ b/fr/compare.md
@@ -121,7 +121,7 @@ Nous pensons que la syntaxe de Riot est le moyen le plus propre de séparer la m
 
 Quand un composant est initialisé, React interprète une chaîne de caractères tandis que Riot traverse un arbre DOM.
 
-Riot récupères les expressions depuis l'arbre et les stockes dans une liste. Chaque expression a un pointeur sur son noeud DOM. A chaque exécution, ces expressions sont évaluées et comparées avec leurs valeurs dans le DOM. Si une valeur a changé, le noeud correspondant est mis à jour dans le DOM. Dans un sens, Riot a aussi un DOM virtuel, juste beaucoup plus simple.
+Riot récupère les expressions depuis l'arbre et les stocke dans une liste. Chaque expression a un pointeur sur son noeud DOM. A chaque exécution, ces expressions sont évaluées et comparées avec leurs valeurs dans le DOM. Si une valeur a changé, le noeud correspondant est mis à jour dans le DOM. Dans un sens, Riot a aussi un DOM virtuel, juste beaucoup plus simple.
 
 Comme les expressions peuvent être mises en cache et que le cycle de mise à jour est très rapide, passer à travers 100 ou 1000 expressions prend généralement 1 milliseconde ou moins.
 
@@ -168,7 +168,7 @@ Le routeur recommandé pour React (v{{ site.react_router.version }}) est {{ site
 <small><em>riot.route.min.js</em> – {{ site.riot_route_size_min }}Ko</small>
 <span class="bar blue" style="width:{{ site.riot_route_size_min | divided_by: site.react_router.size | times:100 }}%"></span>
 
-Nous admettons que la comparaison de ces routeurs n'est pas très juste car [react-router](https://github.com/rackt/react-router) a bien plus de fonctionnalités. Mais le graphique ci-dessus montre clairement l'objectif de Riot: fournir l'API le plus minimaliste pour faire le boulot.
+Nous admettons que la comparaison de ces routeurs n'est pas très juste car [react-router](https://github.com/rackt/react-router) a bien plus de fonctionnalités. Mais le graphique ci-dessus montre clairement l'objectif de Riot: fournir l'API la plus minimaliste pour faire le boulot.
 
 L'écosystème React ressemble plus à un framework et privilégie les API plus vastes. L'alternative plus grosse est davantage populaire que [react-mini-router](https://github.com/larrymyers/react-mini-router) dans la communauté React.
 
@@ -207,7 +207,7 @@ Parce que les Web Components sont un standard, il s'agit de la direction finale 
 
 A cause de la complexité sous-jacente, il y a de fortes chances pour que ces composants ne soient pas utilisés directement. Il y aura des couches par-dessus les Web Components. Tout comme il y a jQuery aujourd'hui. La plupart des gens n'utilisent pas directement le DOM.
 
-Riot est une de ces abstractions. Il fournir une API facile à utiliser sur laquelle nos applications peuvent se reposer. Une fois que la spécification des Web Components aura évolué, Riot pourra l'utiliser *en interne* s'il y a de vrais bénéfices, tels que des gains de performance.
+Riot est une de ces abstractions. Il fournit une API facile à utiliser sur laquelle nos applications peuvent se reposer. Une fois que la spécification des Web Components aura évolué, Riot pourra l'utiliser *en interne* s'il y a de vrais bénéfices, tels que des gains de performance.
 
 Le but de Riot est de rendre le développement d'interfaces utilisateur aussi facile que possible. L'API actuelle est conçue pour résister au flux constant des technologies Web. Vous pouvez le comparer à un "jQuery pour les Web Components" - il prend des raccourcis syntaxiques pour parvenir au même but. Il simplifie l'expérience globale de l'écriture de composants réutilisables.
 

--- a/fr/faq.md
+++ b/fr/faq.md
@@ -43,7 +43,7 @@ Cela affiche `0` et `false` mais `null` et `undefined` sont affichées comme une
 
 
 ## Puis-je utiliser des balises `style` dans un fichier .tag ?
-Oui. Vous pouvez utiliser du CSS normalement à l'intérieur d'une tag personnalisé. Le standard Web Components a aussi un mécanisme pour encapsuler du CSS. Cependant, il est peu probable que cela améliore la gestion globale de votre CSS.
+Oui. Vous pouvez utiliser du CSS normalement à l'intérieur d'un tag personnalisé. Le standard Web Components a aussi un mécanisme pour encapsuler du CSS. Cependant, il est peu probable que cela améliore la gestion globale de votre CSS.
 
 
 ## Quel est le rôle de jQuery?

--- a/fr/index.md
+++ b/fr/index.md
@@ -69,7 +69,7 @@ Un tag personnalisé colle ensemble le HTML correspondant et le JavaScript pour 
 
 ### Lisible par les humains
 
-Les tags personnalisés permettent de concevoir des vues complexes avec HTML. Votre application ressemblera peut-être à quelque-chose comme ça:
+Les tags personnalisés permettent de concevoir des vues complexes avec HTML. Votre application ressemblera peut-être à quelque chose comme ça:
 
 ``` html
 <body>
@@ -91,7 +91,7 @@ Les tags personnalisés permettent de concevoir des vues complexes avec HTML. Vo
 
 La syntaxe HTML est le langage *de facto* du Web et a été conçu pour faire des interfaces utilisateur. La syntaxe est explicite, l'imbrication des éléments est inhérente au langage, et les attributs offrent un moyen propre pour fournir des options aux tags personnalisés.
 
-Les tags Riot sont [compilés](/guide/compiler/) en JavaScript pur avant que les navigateurs puissent les exécuter..
+Les tags Riot sont [compilés](/guide/compiler/) en JavaScript pur avant que les navigateurs puissent les exécuter.
 
 
 ### DOM virtuel


### PR DESCRIPTION
The commit fixes spellings errors in .md files for the french version of the website. It improves the quality of the translation without changing the sense of the sentences.

French is my native tongue.

I sent it against master branch because I didn't see a 'fr' branch in the github pull-request interface. If it's not correct, please say which branch I should use.