### PR TITLE
allowing overflow of code examples to be scrolled through for mobile

### DIFF
--- a/style/_code.scss
+++ b/style/_code.scss
@@ -36,6 +36,7 @@ pre code {
   line-height: 1.4;
   background-color: #f9f9f9;
   border-radius: .25rem;
+  overflow-x: scroll;
 
   pre {
     margin-bottom: 0;


### PR DESCRIPTION
Simply added `overflow-x: scroll` to .highlight so you can scroll inside a code block.