### PR TITLE
Remove old note from download page

### DIFF
--- a/es/download.md
+++ b/es/download.md
@@ -70,12 +70,6 @@ Vea nuestro [historial de versiones](/es/release-notes). Todos los archivos son 
 
 `git clone git@github.com:riot/riot.git`
 
-
-## Problemas conocidos
-
-- Los bucles sobre filas o celdas de una tabla con el atributo `each` no están trabajando en IE8 e IE9.
-
-
 ## Logotipo
 
 ![](/img/logo/riot480x.png)


### PR DESCRIPTION
This note was deleted from the english version.
pd:not sure if PR against this branch or es/2.3.1 (because it doesn't have an es folder)