### PR TITLE
Missing line return to render correctly the subtitle LiveScript

### DIFF
--- a/guide/compiler.md
+++ b/guide/compiler.md
@@ -345,6 +345,7 @@ A sample tag written in TypeScript:
 ``` sh
 npm install typescript-simple
 ```
+
 ### LiveScript
 
 Check out [LiveScript](http://livescript.net) for language features and documentation.


### PR DESCRIPTION
See the current screenshot from the section LiveScript at http://riotjs.com/guide/compiler/#pre-processors. Hence, my PR
![issue-doc-riotjs](https://cloud.githubusercontent.com/assets/642120/14062525/341a9bf2-f3a2-11e5-8bd9-9d8648041c2e.png)
