### PR TITLE
Add hint about using attributes on root tag definitions

### DIFF
--- a/guide/index.md
+++ b/guide/index.md
@@ -74,6 +74,7 @@ A Riot tag is a combination of layout (HTML) and logic (JavaScript). Here are th
 * Self-closing tags are supported: `<div/>` equals `<div></div>`. Well known "open tags" such as `<br>`, `<hr>`, `<img>` or `<input>` are never closed after the compilation.
 * Custom tags always need to be closed (normally or self-closed).
 * Standard HTML tags (`label`, `table`, `a` etc..) can also be customized, but not necessarily a wise thing to do.
+* Tag definition **root** may also have attributes: `<foo onclick={ click } class={ active: active }>`.
 
 
 Tag definition in tag files always starts on the beginning of the line:


### PR DESCRIPTION
Added some hint about using attributes on root tag definitions because it is not mentioned anywhere else in the docs, no examples using it anywhere and this wasn't a working feature in the early versions of riot 2.0.

See https://github.com/riot/riot/issues/1734