### PR TITLE
remove the expected update delay in cdnjs

### DIFF
--- a/es/download.md
+++ b/es/download.md
@@ -41,9 +41,6 @@ Vea nuestro [historial de versiones](/es/release-notes). Todos los archivos son 
 
 #### [cdnjs](https://cdnjs.com/libraries/riot)
 
-**NOTA** La versión {{ site.version }} fue liberada en **{{ site.release_date }}** y CDNJS toma alrededor de 30 horas en actualizarla.
-
-
 `{{ page.cdnjs }}/{{ site.version }}/riot+compiler.min.js`
 
 `{{ page.cdnjs }}/{{ site.version }}/riot.min.js`

--- a/fr/download.md
+++ b/fr/download.md
@@ -37,9 +37,6 @@ Voir notre [historique des versions](/fr/release-notes). Tous les fichiers sont 
 
 #### [cdnjs](https://cdnjs.com/libraries/riot)
 
-**NOTE** La v{{ site.version }} a été livrée le **{{ site.release_date }}** et CDNJS met environ 30 heures pour mettre à jour.
-
-
 `{{ page.cdnjs }}/{{ site.version }}/riot+compiler.min.js`
 
 `{{ page.cdnjs }}/{{ site.version }}/riot.min.js`

--- a/ja/download.md
+++ b/ja/download.md
@@ -41,9 +41,6 @@ class: download
 
 #### [cdnjs](https://cdnjs.com/libraries/riot)
 
-**NOTE** v{{ site.version }}は **{{ site.release_date }}** に公開されました。CDNJSが更新されるまで、30時間程度かかる場合があります。
-
-
 `{{ page.cdnjs }}/{{ site.version }}/riot+compiler.min.js`
 
 `{{ page.cdnjs }}/{{ site.version }}/riot.min.js`

--- a/ru/download.md
+++ b/ru/download.md
@@ -41,9 +41,6 @@ class: download
 
 #### [cdnjs](https://cdnjs.com/libraries/riot)
 
-**Внимание** последняя версия v{{ site.version }} была опубликована **{{ site.release_date }}** и обновление на CDNJS занимает около 30 часов.
-
-
 `{{ page.cdnjs }}/{{ site.version }}/riot+compiler.min.js`
 
 `{{ page.cdnjs }}/{{ site.version }}/riot.min.js`

--- a/zh/download.md
+++ b/zh/download.md
@@ -41,9 +41,6 @@ class: download
 
 #### [cdnjs](https://cdnjs.com/libraries/riot)
 
-**NOTE** v{{ site.version }} 发布于 **{{ site.release_date }}** CDNJS 可能有约 30 小时的更新延迟.
-
-
 `{{ page.cdnjs }}/{{ site.version }}/riot+compiler.min.js`
 
 `{{ page.cdnjs }}/{{ site.version }}/riot.min.js`


### PR DESCRIPTION
Hi there,

Since we've changed the update process, there won't be a long delay anymore, the updates now are very fast, so I think we can remove this note, thanks.