### PR TITLE
Avoid forum url favicons to break into next line

### DIFF
--- a/style/_base.scss
+++ b/style/_base.scss
@@ -85,11 +85,17 @@ a {
   }
 }
 
-#main img {
-  display: block;
-  max-width: 100%;
-  margin: 0 0 1rem;
-  border-radius: 5px;
+#main {
+  img {
+    display: block;
+    max-width: 100%;
+    margin: 0 0 1rem;
+    border-radius: 5px;
+  }
+  .m-body img {
+    margin: 0;
+    display: inline;
+  }
 }
 
 table {


### PR DESCRIPTION
This #50 issue bugged me for a year now. This simple fix will avoid forum inline images/favicons to break into next line.