### PR TITLE
update Japanese Document about 'ja/guide/compiler'

### DIFF
--- a/ja/api/compiler.md
+++ b/ja/api/compiler.md
@@ -161,7 +161,7 @@ riot.parsers.js.myparser = function(js) {
 - `livescript`
 - `typescript`
 - `es6` - (`babel-core`または`babel`を使用)
-- `babel` - (`babel-core` v6.x と`es2015`プリセットを使用)
+- `babel` - (`babel-core` v6.x または`es2015`プリセットを使用)
 - `coffee` または `coffeescript`
 
 ## v2.3.0における変更

--- a/ja/api/compiler.md
+++ b/ja/api/compiler.md
@@ -161,7 +161,7 @@ riot.parsers.js.myparser = function(js) {
 - `livescript`
 - `typescript`
 - `es6` - (`babel-core`または`babel`を使用)
-- `babel` - (`babel-core` v6.x または`es2015`プリセットを使用)
+- `babel` - (`babel-core` v6.x と`es2015`プリセットを使用)
 - `coffee` または `coffeescript`
 
 ## v2.3.0における変更


### PR DESCRIPTION
`ja/guide/compiler`ページの修正になります。

差分は[こちら](http://www.mergely.com/ZVTNuHkQ/)になります。
※差分のみならず、例えば`ES6 Config file`の項目が丸っとなかったりしましたので、差分以外の後も追加・変更しました。
