### PR TITLE
Fix Visual Issue from Unrecognized Highlight Lang

### DIFF
--- a/guide/compiler.md
+++ b/guide/compiler.md
@@ -375,7 +375,7 @@ riot --template pug source.tag
 
 A Pug sample:
 
-``` pug
+``` html
 sample
   p test { value }
   script(type='text/coffee').


### PR DESCRIPTION
Currently looks like this:
<img width="1215" alt="compiler_ _riot_js_" src="https://cloud.githubusercontent.com/assets/1335311/25308759/f9ac3fc6-2789-11e7-984a-112da2e80e1c.png">

With the fix:
<img width="1231" alt="compiler_ _riot_js_" src="https://cloud.githubusercontent.com/assets/1335311/25308776/3d261812-278a-11e7-955a-de566fa70063.png">
