### PR TITLE
Add: Riot DOM Caveats

### DIFF
--- a/ja/guide/index.md
+++ b/ja/guide/index.md
@@ -987,3 +987,37 @@ console.log(html) // <timer><p>Seconds Elapsed: 42</p></timer>
 ```
 
 ループと、条件属性がサポートされています。
+
+
+
+## RiotのDOMの取り扱いにおける注意事項
+
+Riotタグはブラウザのレンダリング処理に依存しているため、特定の状況では、作成したコンポーネント（訳注: Riotタグのこと）のテンプレート記述が正しくレンダリングされないことに注意しましょう。
+
+
+次のRiotタグを考えてみましょう:
+
+``` html
+
+<my-fancy-options>
+  <option>foo</option>
+  <option>bar</option>
+</my-fancy-options>
+```
+
+このマークアップは、`<select>`タグに差し込まれなければ正しいHTMLにはなりませんが、その際に気を付けなければならないことがあります:
+
+``` html
+
+<!-- こちらは間違った記述。selectタグの子要素には<option>しか認められていないためです。 -->
+<select>
+  <my-fancy-options />
+</select>
+
+<!-- こちらが正しい記述。こうすることでRiotは、<select>を<my-fancy-options>の「ルート」ノード とみなし、<option>タグを出力します -->
+<select data-is='my-fancy-options'></select>
+
+```
+
+`table, select, svg...`といったタグは、カスタムタグを子要素にすることを認めていません。そのため、Riotのカスタムタグ（`<virtual>`であっても）の使用も禁止です。代わりに、上の例のように`data-is`を使いましょう。[この件の詳細は、こちらのイシューをご確認ください（英語）](https://github.com/riot/riot/issues/2206)。
+


### PR DESCRIPTION
1008行目の原文は"This markup is not valid if not injected in a `<select>` tag:"ですが、最後のコロンが伝えんとするニュアンス（いまからの記述は、これまでの記述を踏まえたものである）を訳出するために、原文にはない「が、その際に気を付けなければならないことがあります」を付け加えました。この用途でのコロンを日常的に使わない日本語話者には、文章で前段を受けないと唐突でちぐはぐな印象を与えると判断したためです。この説が言いたいことはまさにこの「HTMLにおける不正な子要素はRiotタグも例外ではない」であるため、ここでは原文をそのまま置き換えることより、日本語としてのわかりやすさを優先しました。