### PR TITLE
changing sample code of pug (jade)

### DIFF
--- a/guide/compiler.md
+++ b/guide/compiler.md
@@ -374,10 +374,39 @@ riot --template pug source.tag
 A Pug sample:
 
 ``` html
-sample
-  p test { value }
-  script(type='text/coffee').
-    @value = 'sample'
+todo
+  h3 Todo
+  ul
+    li(each="{ items }")
+      label(class="{ completed:done }")
+        input(type="checkbox", checked="{ done }", onclick="{ parent.toggle }")
+        = "{ title }"
+
+  form(onsubmit="{add}")
+    input(name="input", onkeyup="{edit}")
+    button(disabled="{!text}")= "Add { items.length + 1 }"
+
+  script.
+    var self = this
+    self.items = []
+    self.disabled = true
+
+    edit(e) {
+      self.text = e.target.value
+    }
+
+    add(e) {
+      if (this.text) {
+        self.items.push({ title: this.text })
+        this.text = this.input.value = ''
+      }
+    }
+
+    toggle(e) {
+      var item = e.item
+      item.done = !item.done
+      return true
+    }
 ```
 
 As you notice, you can define the script type on the template as well. Above we use coffee. [pug](https://github.com/pugjs/pug) is used for the transformation:

--- a/guide/compiler.md
+++ b/guide/compiler.md
@@ -409,7 +409,7 @@ todo
     }
 ```
 
-As you notice, you can define the script type on the template as well. Above we use coffee. [pug](https://github.com/pugjs/pug) is used for the transformation:
+As you notice, you can define the script type on the template as well. [pug](https://github.com/pugjs/pug) is used for the transformation:
 
 ``` sh
 npm install pug -g

--- a/ja/guide/compiler.md
+++ b/ja/guide/compiler.md
@@ -409,7 +409,7 @@ todo
     }
 ```
 
-周知の通り、テンプレートにもスクリプトの種類を定義することができます。上記はcoffeeを使っています。 [pug](https://github.com/pugjs/pug)が変換に使われます:
+周知の通り、テンプレートにもスクリプトの種類を定義することができます。 [pug](https://github.com/pugjs/pug)が変換に使われます:
 
 ``` sh
 npm install pug -g

--- a/ja/guide/compiler.md
+++ b/ja/guide/compiler.md
@@ -374,10 +374,39 @@ riot --template pug source.tag
 Pugの例:
 
 ``` js
-sample
-  p test { value }
-  script(type='text/coffee').
-    @value = 'sample'
+todo
+  h3 Todo
+  ul
+    li(each="{ items }")
+      label(class="{ completed:done }")
+        input(type="checkbox", checked="{ done }", onclick="{ parent.toggle }")
+        = "{ title }"
+
+  form(onsubmit="{add}")
+    input(name="input", onkeyup="{edit}")
+    button(disabled="{!text}")= "Add { items.length + 1 }"
+
+  script.
+    var self = this
+    self.items = []
+    self.disabled = true
+
+    edit(e) {
+      self.text = e.target.value
+    }
+
+    add(e) {
+      if (this.text) {
+        self.items.push({ title: this.text })
+        this.text = this.input.value = ''
+      }
+    }
+
+    toggle(e) {
+      var item = e.item
+      item.done = !item.done
+      return true
+    }
 ```
 
 周知の通り、テンプレートにもスクリプトの種類を定義することができます。上記はcoffeeを使っています。 [pug](https://github.com/pugjs/pug)が変換に使われます:


### PR DESCRIPTION
I changed the sample code of pug(jade) of compiler.md to as described by issue.
However, only `en` and `ja` are. Because only these two have been updated.

reference: [issue #77 ](https://github.com/riot/riot.github.io/issues/77#issuecomment-219254198)