### PR TITLE
Color contrast

### DIFF
--- a/style/_code.scss
+++ b/style/_code.scss
@@ -11,7 +11,7 @@ pre {
 code {
   padding: .25em .5em;
   font-size: 70%;
-  color: #53A0CD;
+  color: #058;
   background-color: #f9f9f9;
   border-radius: 3px;
 }
@@ -54,4 +54,3 @@ pre code {
             user-select: none;
   }
 }
-

--- a/style/_syntax.scss
+++ b/style/_syntax.scss
@@ -1,63 +1,96 @@
+$comment:           #667;
+$comment-multi:     #09f;
+$comment-preproc:   #099;
+$error:             #53A0CD;
+$error-generic:     #f00;
+$header-generic:    #030;
+$keyword:           #069;
+$keyword-type:      #078;
+$name-attr:         #4f9fcf;
+$name-builtin:      #366;
+$name-class:        #0a8;
+$name-const:        #360;
+$name-exception:    #c00;
+$name-function:     #c0f;
+$name-label:        #99f;
+$name-namespace:    #0cf;
+$name-tag:          #2f6f9f;
+$name-variable:     #033;
+$num-lit:           #f60;
+$operator:          #555;
+$operator-word:     #000;
+$output-generic:    #aaa;
+$prompt:            #009;
+$str-lit:           #c30;
+$str-lit-interp:    #a00;
+$str-regex:         #3aa;
+$str-symbol:        #fc3;
+$text-whitespace:   #bbb;
+$traceback:         #9c6;
+
+.highlight *::-moz-selection { background: rgba(200, 200, 250, .3);  }
+.highlight *::selection { background: rgba(200, 200, 250, .3);  }
+
 .highlight .hll { background-color: #ffc; }
-.highlight .c { color: #999; } /* Comment */
-.highlight .err, .highlight .s { color: #53A0CD; } /* Error */
-.highlight .k { color: #069; } /* Keyword */
-.highlight .o { color: #555 } /* Operator */
-.highlight .cm { color: #09f; font-style: italic } /* Comment.Multiline */
-.highlight .cp { color: #099 } /* Comment.Preproc */
-.highlight .c1 { color: #999; } /* Comment.Single */
-.highlight .cs { color: #999; } /* Comment.Special */
-.highlight .gd { background-color: #fcc; border: 1px solid #c00 } /* Generic.Deleted */
+.highlight .c { color: $comment; } /* Comment */
+.highlight .err, .highlight .s { color: $error; } /* Error */
+.highlight .k { color: $keyword; } /* Keyword */
+.highlight .o { color: $operator; } /* Operator */
+.highlight .cm { color: $comment-multi; font-style: italic } /* Comment.Multiline */
+.highlight .cp { color: $comment-preproc; } /* Comment.Preproc */
+.highlight .c1 { color: $comment; } /* Comment.Single */
+.highlight .cs { color: $comment; } /* Comment.Special */
+.highlight .gd { background-color: #fcc; border: 1px solid $name-exception; } /* Generic.Deleted */
 .highlight .ge { font-style: italic } /* Generic.Emph */
-.highlight .gr { color: #f00 } /* Generic.Error */
-.highlight .gh { color: #030; } /* Generic.Heading */
+.highlight .gr { color: $error-generic; } /* Generic.Error */
+.highlight .gh { color: $header-generic; } /* Generic.Heading */
 .highlight .gi { background-color: #cfc; border: 1px solid #0c0 } /* Generic.Inserted */
-.highlight .go { color: #aaa } /* Generic.Output */
-.highlight .gp { color: #009; } /* Generic.Prompt */
+.highlight .go { color: $output-generic; } /* Generic.Output */
+.highlight .gp { color: $prompt; } /* Generic.Prompt */
 .highlight .gs { } /* Generic.Strong */
-.highlight .gu { color: #030; } /* Generic.Subheading */
-.highlight .gt { color: #9c6 } /* Generic.Traceback */
-.highlight .kc { color: #069; } /* Keyword.Constant */
-.highlight .kd { color: #069; } /* Keyword.Declaration */
-.highlight .kn { color: #069; } /* Keyword.Namespace */
-.highlight .kp { color: #069 } /* Keyword.Pseudo */
-.highlight .kr { color: #069; } /* Keyword.Reserved */
-.highlight .kt { color: #078; } /* Keyword.Type */
-.highlight .m { color: #f60 } /* Literal.Number */
-.highlight .na { color: #4f9fcf } /* Name.Attribute */
-.highlight .nb { color: #366 } /* Name.Builtin */
-.highlight .nc { color: #0a8; } /* Name.Class */
-.highlight .no { color: #360 } /* Name.Constant */
-.highlight .nd { color: #99f } /* Name.Decorator */
-.highlight .ni { color: #999; } /* Name.Entity */
-.highlight .ne { color: #c00; } /* Name.Exception */
-.highlight .nf { color: #c0f } /* Name.Function */
-.highlight .nl { color: #99f } /* Name.Label */
-.highlight .nn { color: #0cf; } /* Name.Namespace */
-.highlight .nt { color: #2f6f9f; } /* Name.Tag */
-.highlight .nv { color: #033 } /* Name.Variable */
-.highlight .ow { color: #000; } /* Operator.Word */
-.highlight .w { color: #bbb } /* Text.Whitespace */
-.highlight .mf { color: #f60 } /* Literal.Number.Float */
-.highlight .mh { color: #f60 } /* Literal.Number.Hex */
-.highlight .mi { color: #f60 } /* Literal.Number.Integer */
-.highlight .mo { color: #f60 } /* Literal.Number.Oct */
-.highlight .sb { color: #c30 } /* Literal.String.Backtick */
-.highlight .sc { color: #c30 } /* Literal.String.Char */
-.highlight .sd { color: #c30; font-style: italic } /* Literal.String.Doc */
-.highlight .s2 { color: #c30 } /* Literal.String.Double */
-.highlight .se { color: #c30; } /* Literal.String.Escape */
-.highlight .sh { color: #c30 } /* Literal.String.Heredoc */
-.highlight .si { color: #a00 } /* Literal.String.Interpol */
-.highlight .sx { color: #c30 } /* Literal.String.Other */
-.highlight .sr { color: #3aa } /* Literal.String.Regex */
-.highlight .s1 { color: #c30 } /* Literal.String.Single */
-.highlight .ss { color: #fc3 } /* Literal.String.Symbol */
-.highlight .bp { color: #366 } /* Name.Builtin.Pseudo */
-.highlight .vc { color: #033 } /* Name.Variable.Class */
-.highlight .vg { color: #033 } /* Name.Variable.Global */
-.highlight .vi { color: #033 } /* Name.Variable.Instance */
-.highlight .il { color: #f60 } /* Literal.Number.Integer.Long */
+.highlight .gu { color: $header-generic; } /* Generic.Subheading */
+.highlight .gt { color: $traceback; } /* Generic.Traceback */
+.highlight .kc { color: $keyword; } /* Keyword.Constant */
+.highlight .kd { color: $keyword; } /* Keyword.Declaration */
+.highlight .kn { color: $keyword; } /* Keyword.Namespace */
+.highlight .kp { color: $keyword; } /* Keyword.Pseudo */
+.highlight .kr { color: $keyword; } /* Keyword.Reserved */
+.highlight .kt { color: $keyword-type; } /* Keyword.Type */
+.highlight .m { color: $num-lit; } /* Literal.Number */
+.highlight .na { color: $name-attr; } /* Name.Attribute */
+.highlight .nb { color: $name-builtin; } /* Name.Builtin */
+.highlight .nc { color: $name-class; } /* Name.Class */
+.highlight .no { color: $name-const; } /* Name.Constant */
+.highlight .nd { color: $name-label; } /* Name.Decorator */
+.highlight .ni { color: $comment; } /* Name.Entity */
+.highlight .ne { color: $name-exception; } /* Name.Exception */
+.highlight .nf { color: $name-function; } /* Name.Function */
+.highlight .nl { color: $name-label; } /* Name.Label */
+.highlight .nn { color: $name-namespace; } /* Name.Namespace */
+.highlight .nt { color: $name-tag; } /* Name.Tag */
+.highlight .nv { color: $name-variable; } /* Name.Variable */
+.highlight .ow { color: $operator-word; } /* Operator.Word */
+.highlight .w { color: $text-whitespace; } /* Text.Whitespace */
+.highlight .mf { color: $num-lit; } /* Literal.Number.Float */
+.highlight .mh { color: $num-lit; } /* Literal.Number.Hex */
+.highlight .mi { color: $num-lit; } /* Literal.Number.Integer */
+.highlight .mo { color: $num-lit; } /* Literal.Number.Oct */
+.highlight .sb { color: $str-lit; } /* Literal.String.Backtick */
+.highlight .sc { color: $str-lit; } /* Literal.String.Char */
+.highlight .sd { color: $str-lit; font-style: italic; } /* Literal.String.Doc */
+.highlight .s2 { color: $str-lit; } /* Literal.String.Double */
+.highlight .se { color: $str-lit; } /* Literal.String.Escape */
+.highlight .sh { color: $str-lit; } /* Literal.String.Heredoc */
+.highlight .si { color: $str-lit-interp; } /* Literal.String.Interpol */
+.highlight .sx { color: $str-lit; } /* Literal.String.Other */
+.highlight .sr { color: $str-regex; } /* Literal.String.Regex */
+.highlight .s1 { color: $str-lit; } /* Literal.String.Single */
+.highlight .ss { color: $str-symbol; } /* Literal.String.Symbol */
+.highlight .bp { color: $name-builtin; } /* Name.Builtin.Pseudo */
+.highlight .vc { color: $name-variable; } /* Name.Variable.Class */
+.highlight .vg { color: $name-variable; } /* Name.Variable.Global */
+.highlight .vi { color: $name-variable; } /* Name.Variable.Instance */
+.highlight .il { color: $num-lit; } /* Literal.Number.Integer.Long */
 
 .css .o,
 .css .o + .nt,

--- a/style/_syntax.scss
+++ b/style/_syntax.scss
@@ -1,35 +1,35 @@
 $comment:           #667;
-$comment-multi:     #09f;
+$comment-multi:     #3F7E3E;
 $comment-preproc:   #099;
-$error:             #53A0CD;
-$error-generic:     #f00;
+$error:             #2f6f9f;
+$error-generic:     #c00;
 $header-generic:    #030;
 $keyword:           #069;
 $keyword-type:      #078;
-$name-attr:         #4f9fcf;
+$name-attr:         #0184BC;
 $name-builtin:      #366;
-$name-class:        #0a8;
+$name-class:        #986801;
 $name-const:        #360;
 $name-exception:    #c00;
 $name-function:     #c0f;
-$name-label:        #99f;
-$name-namespace:    #0cf;
-$name-tag:          #2f6f9f;
+$name-label:        #46c;
+$name-namespace:    #0184BC;
+$name-tag:          #A626A4;
 $name-variable:     #033;
 $num-lit:           #f60;
 $operator:          #555;
 $operator-word:     #000;
-$output-generic:    #aaa;
+$output-generic:    #353535;
 $prompt:            #009;
 $str-lit:           #c30;
 $str-lit-interp:    #a00;
 $str-regex:         #3aa;
 $str-symbol:        #fc3;
-$text-whitespace:   #bbb;
+$text-whitespace:   #777;
 $traceback:         #9c6;
 
-.highlight *::-moz-selection { background: rgba(200, 200, 250, .3);  }
-.highlight *::selection { background: rgba(200, 200, 250, .3);  }
+.highlight *::-moz-selection { background: rgba(220, 220, 255, .5);  }
+.highlight *::selection { background: rgba(220, 220, 255, .5);  }
 
 .highlight .hll { background-color: #ffc; }
 .highlight .c { color: $comment; } /* Comment */


### PR DESCRIPTION
#34 

- Update the style sheets to improve the color contrast between some syntax highlighter elements and the background.
- Use SASS variables for highlighter colors
- Added ::selection pseduclass to improve contrast when a user selects text on code segments
