### PR TITLE
Use actual main.js path in example

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -39,7 +39,7 @@ Once you have wired all your application bundler that's how your code might look
 </head>
 <body>
   <app></app>
-  <script src="path/to/your/main.js"></script>
+  <script src="main.js"></script>
 </body>
 </html>
 ```


### PR DESCRIPTION
I recommend using a real path to main.js in the quick start section. That way if someone copies the three files (index.html, app.riot, main.js) into the same directory, they will work.

If it's really necessary to inform readers that they should use the path to *their* main.js file, perhaps a comment in the code would be more appropriate.