### PR TITLE
Fix typescript module name in import

### DIFF
--- a/compiler.md
+++ b/compiler.md
@@ -272,7 +272,7 @@ The `@riotjs/compiler` gives you the possibility to register your preprocessors:
 import { registerPreprocessor } from '@riotjs/compiler'
 import pug from 'pug'
 import sass from 'node-sass'
-import ts from 'ts'
+import ts from 'typescript'
 
 registerPreprocessor('template', 'pug', function(code, { options }) {
   const { file } = options

--- a/ja/compiler.md
+++ b/ja/compiler.md
@@ -272,7 +272,7 @@ riot app.js -o dist/app.js
 import { registerPreprocessor } from '@riotjs/compiler'
 import pug from 'pug'
 import sass from 'node-sass'
-import ts from 'ts'
+import ts from 'typescript'
 
 registerPreprocessor('template', 'pug', function(code, { options }) {
   const { file } = options


### PR DESCRIPTION
[ts](https://www.npmjs.com/package/ts) is a CLI tool, the right module to import is `typescript`.
This fixes "Error: Cannot find module 'ts'" on builds