### PR TITLE
[Fix] SCSS registerPreprocessor example

### DIFF
--- a/compiler.md
+++ b/compiler.md
@@ -295,7 +295,7 @@ registerPreprocessor('css', 'sass', function(code, { options }) {
   })
 
   return {
-    code: css.css.toString(),
+    code: css.toString(),
     map: null
   }
 })


### PR DESCRIPTION
Using the preprocessor example was giving errors due to a simple typo.

Converting the buffer to the string should be done by `css.toString()`.