### PR TITLE
`$` and `$` helper requires `this`

### DIFF
--- a/ja/migration-guide.md
+++ b/ja/migration-guide.md
@@ -343,7 +343,7 @@ riot.install(function(componentAPI) {
   <script>
     export default {
       onMounted() {
-        const paragraph = $('p')
+        const paragraph = this.$('p')
 
         paragraph.innerHTML = '<b>hello</b>'
       }

--- a/migration-guide.md
+++ b/migration-guide.md
@@ -343,7 +343,7 @@ The `ref` attributes were replaced by the `$` and `$$` [component helpers]({{ '/
   <script>
     export default {
       onMounted() {
-        const paragraph = $('p')
+        const paragraph = this.$('p')
 
         paragraph.innerHTML = '<b>hello</b>'
       }


### PR DESCRIPTION
In my case, only `$` or `$` helper was not function.
I think it should be `this.$` or `this.$$`.