### PR TITLE
Fix font-size rendering of pre tag on iOS Safari

### DIFF
--- a/style/_typography.scss
+++ b/style/_typography.scss
@@ -7,6 +7,7 @@ body {
   font-family: $font-family;
   color: $dark-grey;
   line-height: 1.4;
+  -webkit-text-size-adjust: 100%;
 
   @at-root .dark {
     background: $carbon-black;


### PR DESCRIPTION
Fixed large rendering of some text sizes in iOS Safari.

Examples of large renderings:
<img width="687" alt="スクリーンショット 2020-07-01 8 12 54" src="https://user-images.githubusercontent.com/35029412/86186700-aeb63a80-bb74-11ea-9624-6230d96ef75f.png">
